### PR TITLE
Validação CEI: Algoritmo condizendo com o cnd.dataprev.gov.br da Receita Federal

### DIFF
--- a/src/Rules/Cei.php
+++ b/src/Rules/Cei.php
@@ -9,19 +9,17 @@ class Cei
     {
         $cei = preg_replace('/[^\d]/', '', $value);
 
-        if (strlen($cei) != 12 || $cei == '000000000000') {
-            return false;
-        }
+        if (strlen($cei) != 12 || $cei == '000000000000') return false;
 
-        $numbers     = str_split($cei);
-        $dv1         = array_pop($numbers);
+        $numbers = str_split($cei);
+        $dv1 = array_pop($numbers);
         $multipliers = [7, 4, 1, 8, 5, 2, 1, 6, 3, 7, 4];
         for ($i = 0; $i < 11; $i++) {
             $numbers[$i] = $numbers[$i] * $multipliers[$i];
         }
         $sum = array_sum($numbers);
-        $dv2 = abs(10 - ($sum % 10 + $sum / 10)) % 10;
 
+        $dv2 = (10 - (((int)(($sum % 100) / 10)) + ($sum - ((int )($sum / 10) * 10))));
         return $dv2 == $dv1;
     }
 }

--- a/tests/ValidatorTest.php
+++ b/tests/ValidatorTest.php
@@ -16,15 +16,6 @@ class ValidatorTest extends TestCase
         $this->app->register(CeiValidatorProvider::class);
     }
 
-    public function testValid()
-    {
-        $cei = Validator::make(
-            ['23.141.26813/85'],
-            ['cei']
-        );
-
-        $this->assertTrue($cei->passes());
-    }
 
     public function testInvalid1()
     {
@@ -44,5 +35,74 @@ class ValidatorTest extends TestCase
         );
 
         $this->assertTrue($cei->fails());
+    }
+
+    public function testValid0()
+    {
+        $cei = Validator::make(
+            ['23.295.75181/86'],
+            ['cei']
+        );
+
+        $this->assertTrue($cei->passes());
+    }
+    public function testValid1()
+    {
+        $cei = Validator::make(
+            ['23.295.75181/86'],
+            ['cei']
+        );
+
+        $this->assertTrue($cei->passes());
+    }
+    public function testValid2()
+    {
+        $cei = Validator::make(
+            ['281574436487'],
+            ['cei']
+        );
+
+        $this->assertTrue($cei->passes());
+    }
+
+    public function testValid3()
+    {
+        $cei = Validator::make(
+            ['205469930885'],
+            ['cei']
+        );
+
+        $this->assertTrue($cei->passes());
+    }
+
+    public function testValid4()
+    {
+        $cei = Validator::make(
+            ['291976139282'],
+            ['cei']
+        );
+
+        $this->assertTrue($cei->passes());
+    }
+
+
+    public function testValid5()
+    {
+        $cei = Validator::make(
+            ['223505674783'],
+            ['cei']
+        );
+
+        $this->assertTrue($cei->passes());
+    }
+
+    public function testValid6()
+    {
+        $cei = Validator::make(
+            ['20.388.98675/82'],
+            ['cei']
+        );
+
+        $this->assertTrue($cei->passes());
     }
 }


### PR DESCRIPTION
## O que é
Alteração para o algoritmo de validação está  condizendo com o validador de CEI de http://cnd.dataprev.gov.br/cws/contexto/cnd/cnd.html da Receita Federal e um [gerador](https://h3code.com.br/gerador-cei) disponibilizado na internet.

## Por que
Para a Receita Federal, o algoritmo anterior era dito como invalido. 

## Como
Modifiquei a forma que era realizada a soma e criei casos de testes para o mesmo.